### PR TITLE
Use Directory instead of DirectoryOrCreate for PV hostPath type

### DIFF
--- a/provisioner.go
+++ b/provisioner.go
@@ -287,7 +287,7 @@ func (p *LocalPathProvisioner) Provision(opts pvController.ProvisionOptions) (*v
 			},
 		}
 	} else {
-		hostPathType := v1.HostPathDirectoryOrCreate
+		hostPathType := v1.HostPathDirectory
 		pvs = v1.PersistentVolumeSource{
 			HostPath: &v1.HostPathVolumeSource{
 				Path: path,


### PR DESCRIPTION
Until now the created PVs used DirectoryOrCreate for PV hostPath type. If the path was under a mountpoint that is not mounted by default, kubelet will end up creating this path even after the initial provisioning.

Copying from [1]:

  If nothing exists at the given path, an empty directory will be created there
  as needed with permission set to 0755, having the same group and ownership with
  Kubelet.

So after reboot, our pod might start with an empty disk with wrong permissions.

Cherry-pick an unmerged upstream PR [2] that uses Directory instead. So, until the underlying device gets mounted, the pod will fail to start with:

  MountVolume.SetUp failed for volume "pvc-69e8baa8-f3b3-496b-9104-ca80774a3f4f" : hostPath type check failed: /mnt/arrikto/local-path-provisioner/pvc-69e8baa8-f3b3-496b-9104-ca80774a3f4f_rok_data-rok-etcd-0 is not a directory

[1] https://kubernetes.io/docs/concepts/storage/volumes/
[2] https://github.com/rancher/local-path-provisioner/pull/224/

Refs arrikto/rok#7138
Refs rancher/local-path-provisioner#137